### PR TITLE
Handle case where c-default-style is set to a string

### DIFF
--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -249,7 +249,8 @@
                                    (substatement-open     . 0)))))
 
 (eval-and-compile
-  (unless (assoc 'csharp-mode c-default-style)
+  (unless (or (stringp c-default-style)
+              (assoc 'csharp-mode c-default-style))
     (setq c-default-style
           (cons '(csharp-mode . "csharp")
                 c-default-style))))


### PR DESCRIPTION
Currently if c-default-style is set to a single string, this expression fails because it expects an a-list. In order to handle this, I added a simple `stringp` test to the `unless` expression. Another possible way to handle this case would be to create an a-list by setting the current value of `c-default-style` to `other`. That solution would look like:
```elisp
(eval-and-compile
  (unless (assoc 'csharp-mode c-default-style)
    (setq c-default-style
          (if (stringp c-default-style)
              `((csharp-mode . "csharp")
                (other . ,c-default-style))
            (cons '(csharp-mode . "csharp")
                  c-default-style)))))
```
However, I assumed it would be preferable to not override the user's default, but I was not sure which made most since for the mode as a whole.

I also looked at adding tests for this in the tests file, however, I didn't see any other mode setup-related tests. If tests would be preferred, I can look at throwing a few in place.

Thanks!