### PR TITLE
Minor fix after version 0.11.0

### DIFF
--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -8,7 +8,6 @@
 ;; Version    : 0.11.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
-;; Package-Requires: ((emacs "26.1") (tree-sitter "0.12.1") (tree-sitter-indent "0.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -8,6 +8,7 @@
 ;; Version    : 0.11.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
+;; Package-Requires: ((emacs "26.1") (tree-sitter "0.12.1") (tree-sitter-indent "0.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -30,6 +30,8 @@
 (require 'tree-sitter-hl)
 (require 'tree-sitter-indent)
 
+(require 'csharp-mode)
+
 ;;; Tree-sitter
 
 (defvar-local csharp-mode-tree-sitter-patterns

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -233,13 +233,13 @@
                   ))
     (indent-body . ;; if parent node is one of these and current node is in middle → indent
                  (block
-                     anonymous_object_creation_expression
-                   enum_member_declaration_list
-                   initializer_expression
-                   expression_statement
-                   declaration_list
-                   attribute_argument_list
-                   switch_body))
+                  anonymous_object_creation_expression
+                  enum_member_declaration_list
+                  initializer_expression
+                  expression_statement
+                  declaration_list
+                  attribute_argument_list
+                  switch_body))
 
     (paren-indent . ;; if parent node is one of these → indent to paren opener
                   (parenthesized_expression))

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -31,7 +31,8 @@
 (require 'tree-sitter-hl)
 (require 'tree-sitter-indent)
 
-(require 'csharp-mode)
+(defvar cshaerp-mode-syntax-table)
+(defvar csharp-mode-map)
 
 ;;; Tree-sitter
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -8,7 +8,6 @@
 ;; Version    : 0.11.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
-;; Package-Requires: ((emacs "26.1") (tree-sitter "0.12.1") (tree-sitter-indent "0.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -26,11 +26,10 @@
 ;;; Code:
 (require 'cl-lib)
 (require 'seq)
+
 (require 'tree-sitter)
 (require 'tree-sitter-hl)
 (require 'tree-sitter-indent)
-
-(defvar tree-sitter-major-mode-language-alist)
 
 (require 'csharp-mode)
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -108,7 +108,7 @@
    (local_function_statement (nullable_type) @type (identifier) @function)
    (local_function_statement (void_keyword) @type (identifier) @function)
    (local_function_statement (generic_name) (identifier) @function)
-   
+
    ;; Parameter
    (parameter
     type: (identifier) @type
@@ -116,10 +116,10 @@
    (parameter (identifier) @variable)
 
    ;; Array
-   (array_rank_specifier (identifier) @variable) 
+   (array_rank_specifier (identifier) @variable)
    (array_type (identifier) @type)
    (array_creation_expression)
-   
+
    ;; Attribute
    (attribute (identifier) @variable (attribute_argument_list))
    (attribute (identifier) @variable)
@@ -139,7 +139,7 @@
    ;; Return
    (return_statement (identifier) @variable)
    (yield_statement (identifier) @variable)
-   
+
    ;; Type
    (type_parameter
     (identifier) @type)
@@ -161,7 +161,7 @@
    (type_of_expression (identifier) @variable)
    (assignment_expression (identifier) @variable)
    (cast_expression (identifier) @type)
-   
+
    ;; Preprocessor
    (preprocessor_directive) @constant
    (preprocessor_call (identifier) @string)
@@ -178,10 +178,10 @@
    ;; Switch
    (switch_statement (identifier) @variable)
    (switch_expression (identifier) @variable)
-   
+
    ;; If
    (if_statement (identifier) @variable)
-   
+
    ;; Declaration expression
    (declaration_expression (implicit_type) (identifier) @variable)
 
@@ -230,13 +230,13 @@
                   ))
     (indent-body . ;; if parent node is one of these and current node is in middle → indent
                  (block
-                  anonymous_object_creation_expression
-                  enum_member_declaration_list
-                  initializer_expression
-                  expression_statement
-                  declaration_list
-                  attribute_argument_list
-                  switch_body))
+                     anonymous_object_creation_expression
+                   enum_member_declaration_list
+                   initializer_expression
+                   expression_statement
+                   declaration_list
+                   attribute_argument_list
+                   switch_body))
 
     (paren-indent . ;; if parent node is one of these → indent to paren opener
                   (parenthesized_expression))

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -26,11 +26,11 @@
 ;;; Code:
 (require 'cl-lib)
 (require 'seq)
+(require 'tree-sitter)
+(require 'tree-sitter-hl)
+(require 'tree-sitter-indent)
 
-(eval-when-compile
-  (require 'tree-sitter)
-  (require 'tree-sitter-hl)
-  (require 'tree-sitter-indent))
+(defvar tree-sitter-major-mode-language-alist)
 
 (require 'csharp-mode)
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -26,9 +26,11 @@
 ;;; Code:
 (require 'cl-lib)
 (require 'seq)
-(require 'tree-sitter)
-(require 'tree-sitter-hl)
-(require 'tree-sitter-indent)
+
+(eval-when-compile
+  (require 'tree-sitter)
+  (require 'tree-sitter-hl)
+  (require 'tree-sitter-indent))
 
 (require 'csharp-mode)
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -286,7 +286,8 @@ Key bindings:
   (tree-sitter-hl-mode))
 
 ;;;###autoload
-(add-to-list 'tree-sitter-major-mode-language-alist '(csharp-tree-sitter-mode . c-sharp))
+(with-eval-after-load 'tree-sitter
+  (add-to-list 'tree-sitter-major-mode-language-alist '(csharp-tree-sitter-mode . c-sharp)))
 
 (provide 'csharp-tree-sitter)
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -8,6 +8,7 @@
 ;; Version    : 0.11.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
+;; Package-Requires: ((emacs "26.1") (tree-sitter "0.12.1") (tree-sitter-indent "0.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This patch does the following.

- Remove trailing spaces
- Avoid following warnings while installing

```
In csharp-tree-sitter-mode:
csharp-tree-sitter.el:270:9:Warning: assignment to free variable
    ‘csharp-mode-syntax-table’
csharp-tree-sitter.el:271:9:Warning: assignment to free variable
    ‘csharp-mode-map’
```

- Require `tree-sitter` and `tree-sitter-indent` in `csharp-mode.el` instead of `charp-tree-sitter.el` (Not sure if we need to do this, but I am getting the error, see #208)

