### PR TITLE
Support tree-sitter in minor-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -26,8 +26,7 @@ You can enable experimental tree sitter support for indentation and highlighting
   (use-package tree-sitter-langs)
 
   (use-package csharp-mode
-    :config
-    (add-to-list 'auto-mode-alist '("\\.cs\\'" . csharp-tree-sitter-mode)))
+    :hook (csharp-mode . csharp-tree-sitter-mode))
 #+end_src
 If you are using this, clearly state so if you find any issues.
 

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -8,6 +8,7 @@
 ;; Version    : 0.11.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
+;; Package-Requires: ((emacs "26.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -22,6 +23,10 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+;;; Commentary:
+;;
+;; A major-mode for editing C# in Emacs.
+;;
 
 ;;; Code:
 

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -8,7 +8,7 @@
 ;; Version    : 0.11.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
-;; Package-Requires: ((emacs "26.1"))
+;; Package-Requires: ((emacs "25.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -8,7 +8,7 @@
 ;; Version    : 0.11.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
-;; Package-Requires: ((emacs "26.1") (tree-sitter "0.12.1") (tree-sitter-indent "0.1"))
+;; Package-Requires: ((emacs "26.1") (tree-sitter "0.12.1") (tree-sitter-indent "0.1") (tree-sitter-langs "0.9.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -31,6 +31,7 @@
 (require 'tree-sitter)
 (require 'tree-sitter-hl)
 (require 'tree-sitter-indent)
+(require 'tree-sitter-langs)
 
 (defvar csharp-mode-syntax-table)
 (defvar csharp-mode-map)

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -300,7 +300,7 @@
   (if csharp-tree-sitter-mode (csharp-tree-sitter--enable)
     (csharp-tree-sitter--disable)))
 
-(add-to-list 'tree-sitter-major-mode-language-alist '(csharp-tree-sitter-mode . c-sharp))
+(add-to-list 'tree-sitter-major-mode-language-alist '(csharp-mode . c-sharp))
 
 (provide 'csharp-tree-sitter)
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -236,13 +236,13 @@
                   ))
     (indent-body . ;; if parent node is one of these and current node is in middle → indent
                  (block
-                  anonymous_object_creation_expression
-                  enum_member_declaration_list
-                  initializer_expression
-                  expression_statement
-                  declaration_list
-                  attribute_argument_list
-                  switch_body))
+                     anonymous_object_creation_expression
+                   enum_member_declaration_list
+                   initializer_expression
+                   expression_statement
+                   declaration_list
+                   attribute_argument_list
+                   switch_body))
 
     (paren-indent . ;; if parent node is one of these → indent to paren opener
                   (parenthesized_expression))
@@ -296,6 +296,7 @@
 ;;;###autoload
 (define-minor-mode csharp-tree-sitter-mode
   "Minor mode for csharp tree-sitter support."
+  :lighter " C#-TreeSitter"
   :group csharp
   (if csharp-tree-sitter-mode (csharp-tree-sitter--enable)
     (csharp-tree-sitter--disable)))

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -23,6 +23,10 @@
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+;;; Commentary:
+;;
+;; Tree Sitter support for C# mode.
+;;
 
 ;;; Code:
 (require 'cl-lib)

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -270,12 +270,13 @@
 (defvar csharp-tree-sitter-mode-map
   (let ((map (make-sparse-keymap)))
     map)
-  "Keymap used in csharp-mode buffers.")
+  "Keymap used in `csharp-mode' buffers.")
 
 (defvar csharp-tree-sitter-mode-syntax-table
   (let ((table (make-syntax-table)))
     (modify-syntax-entry ?@ "_" table)
-    table))
+    table)
+  "Syntax table used in `csharp-mode' buffers.")
 
 (defvar-local csharp-tree-sitter--syntax-table nil)
 (defvar-local csharp-tree-sitter--mode-map nil)

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -269,29 +269,29 @@
 
 (defun csharp-tree-sitter--enable ()
   "Enable tree-sitter support for csharp."
-  (setq csharp-tree-sitter--syntax-table csharp-mode-syntax-table)
-  (setq csharp-tree-sitter--mode-map csharp-mode-map)
+  (setq csharp-tree-sitter--syntax-table csharp-mode-syntax-table
+        csharp-tree-sitter--mode-map csharp-mode-map)
 
-  (setq csharp-mode-syntax-table nil)
-  (setq csharp-mode-map nil)
-  (setq-local tree-sitter-indent-current-scopes csharp-mode-indent-scopes)
-  (setq-local tree-sitter-indent-offset csharp-mode-indent-offset)
-  (setq-local indent-line-function #'tree-sitter-indent-line)
+  (setq csharp-mode-syntax-table nil
+        csharp-mode-map nil)
+  (setq-local tree-sitter-indent-current-scopes csharp-mode-indent-scopes
+              tree-sitter-indent-offset csharp-mode-indent-offset
+              indent-line-function #'tree-sitter-indent-line)
 
   ;; https://github.com/ubolonton/emacs-tree-sitter/issues/84
   (unless font-lock-defaults
     (setq font-lock-defaults '(nil)))
   (setq-local tree-sitter-hl-default-patterns csharp-mode-tree-sitter-patterns)
   ;; Comments
-  (setq-local comment-start "// ")
-  (setq-local comment-end "")
+  (setq-local comment-start "// " comment-end "")
 
-  (tree-sitter-hl-mode))
+  (tree-sitter-hl-mode 1))
 
 (defun csharp-tree-sitter--disable ()
   "Disable tree-sitter support for csharp."
   (setq csharp-mode-syntax-table csharp-tree-sitter--syntax-table)
-  (setq csharp-mode-map csharp-tree-sitter--mode-map))
+  (setq csharp-mode-map csharp-tree-sitter--mode-map)
+  (tree-sitter-hl-mode -1))
 
 ;;;###autoload
 (define-minor-mode csharp-tree-sitter-mode

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -264,13 +264,13 @@
     )
   "Scopes for indenting in C#.")
 
-;;;###autoload
-(define-derived-mode csharp-tree-sitter-mode prog-mode "C#"
-  "Major mode for editing Csharp code.
+(defvar csharp-tree-sitter--syntax-table)
+(defvar csharp-tree-sitter--mode-map)
 
-Key bindings:
-\\{csharp-mode-map}"
-  :group 'csharp
+(defun csharp-tree-sitter--enable ()
+  "Enable tree-sitter support for csharp."
+  (setq csharp-tree-sitter--syntax-table csharp-mode-syntax-table)
+  (setq csharp-tree-sitter--mode-map csharp-mode-map)
 
   (setq csharp-mode-syntax-table nil)
   (setq csharp-mode-map nil)
@@ -287,6 +287,18 @@ Key bindings:
   (setq-local comment-end "")
 
   (tree-sitter-hl-mode))
+
+(defun csharp-tree-sitter--disable ()
+  "Disable tree-sitter support for csharp."
+  (setq csharp-mode-syntax-table csharp-tree-sitter--syntax-table)
+  (setq csharp-mode-map csharp-tree-sitter--mode-map))
+
+;;;###autoload
+(define-minor-mode csharp-tree-sitter-mode
+  "Minor mode for csharp tree-sitter support."
+  :group csharp
+  (if csharp-tree-sitter-mode (csharp-tree-sitter--enable)
+    (csharp-tree-sitter--disable)))
 
 (add-to-list 'tree-sitter-major-mode-language-alist '(csharp-tree-sitter-mode . c-sharp))
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -293,10 +293,6 @@
   (setq-local tree-sitter-indent-current-scopes csharp-mode-indent-scopes
               tree-sitter-indent-offset csharp-mode-indent-offset
               indent-line-function #'tree-sitter-indent-line)
-<<<<<<< HEAD
-
-=======
->>>>>>> 2403459efd7dcae2c07a12e80ffce15650777629
 
   ;; https://github.com/ubolonton/emacs-tree-sitter/issues/84
   (unless font-lock-defaults

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -216,7 +216,7 @@
   :group 'tree-sitter)
 
 (defcustom csharp-mode-indent-offset 4
-  "Indent offset for csharp-mode"
+  "Indent offset for `csharp-mode'."
   :type 'integer
   :group 'csharp)
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -267,6 +267,16 @@
     )
   "Scopes for indenting in C#.")
 
+(defvar csharp-tree-sitter-mode-map
+  (let ((map (make-sparse-keymap)))
+    map)
+  "Keymap used in csharp-mode buffers.")
+
+(defvar csharp-tree-sitter-mode-syntax-table
+  (let ((table (make-syntax-table)))
+    (modify-syntax-entry ?@ "_" table)
+    table))
+
 (defvar-local csharp-tree-sitter--syntax-table nil)
 (defvar-local csharp-tree-sitter--mode-map nil)
 (defvar-local csharp-tree-sitter--indent-line-function nil)
@@ -278,8 +288,8 @@
         csharp-tree-sitter--mode-map csharp-mode-map
         csharp-tree-sitter--indent-line-function indent-line-function)
 
-  (setq-local csharp-mode-syntax-table (make-syntax-table)
-              csharp-mode-map (make-sparse-keymap))
+  (setq-local csharp-mode-syntax-table csharp-tree-sitter-mode-syntax-table
+              csharp-mode-map csharp-tree-sitter-mode-map)
   (setq-local tree-sitter-indent-current-scopes csharp-mode-indent-scopes
               tree-sitter-indent-offset csharp-mode-indent-offset
               indent-line-function #'tree-sitter-indent-line)

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -278,8 +278,8 @@
         csharp-tree-sitter--mode-map csharp-mode-map
         csharp-tree-sitter--indent-line-function indent-line-function)
 
-  (setq csharp-mode-syntax-table nil
-        csharp-mode-map nil)
+  (setq-local csharp-mode-syntax-table (make-syntax-table)
+              csharp-mode-map (make-sparse-keymap))
   (setq-local tree-sitter-indent-current-scopes csharp-mode-indent-scopes
               tree-sitter-indent-offset csharp-mode-indent-offset
               indent-line-function #'tree-sitter-indent-line)

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -8,7 +8,7 @@
 ;; Version    : 0.11.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
-;; Package-Requires: ((emacs "26.1") (tree-sitter "0.12.1") (tree-sitter-indent "0.1") (tree-sitter-langs "0.9.0"))
+;; Package-Requires: ((emacs "26.1") (csharp-mode "0.11.0") (tree-sitter "0.12.1") (tree-sitter-indent "0.1") (tree-sitter-langs "0.9.0"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -239,13 +239,13 @@
                   ))
     (indent-body . ;; if parent node is one of these and current node is in middle → indent
                  (block
-                     anonymous_object_creation_expression
-                   enum_member_declaration_list
-                   initializer_expression
-                   expression_statement
-                   declaration_list
-                   attribute_argument_list
-                   switch_body))
+                  anonymous_object_creation_expression
+                  enum_member_declaration_list
+                  initializer_expression
+                  expression_statement
+                  declaration_list
+                  attribute_argument_list
+                  switch_body))
 
     (paren-indent . ;; if parent node is one of these → indent to paren opener
                   (parenthesized_expression))

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -267,9 +267,9 @@
     )
   "Scopes for indenting in C#.")
 
-(defvar csharp-tree-sitter--syntax-table)
-(defvar csharp-tree-sitter--mode-map)
-(defvar csharp-tree-sitter--indent-line-function)
+(defvar-local csharp-tree-sitter--syntax-table nil)
+(defvar-local csharp-tree-sitter--mode-map nil)
+(defvar-local csharp-tree-sitter--indent-line-function nil)
 
 (defun csharp-tree-sitter--enable ()
   "Enable tree-sitter support for csharp."
@@ -306,8 +306,10 @@
   "Minor mode for csharp tree-sitter support."
   :lighter " C#-TreeSitter"
   :group csharp
-  (if csharp-tree-sitter-mode (csharp-tree-sitter--enable)
-    (csharp-tree-sitter--disable)))
+  (if (and (eq major-mode 'csharp-mode) csharp-tree-sitter-mode)
+      (csharp-tree-sitter--enable)
+    (csharp-tree-sitter--disable)
+    (user-error "You cannot enable tree-sitter support outside of `csharp-mode`")))
 
 (add-to-list 'tree-sitter-major-mode-language-alist '(csharp-mode . c-sharp))
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -33,8 +33,7 @@
 (require 'tree-sitter-indent)
 (require 'tree-sitter-langs)
 
-(defvar csharp-mode-syntax-table)
-(defvar csharp-mode-map)
+(require 'csharp-mode)
 
 ;;; Tree-sitter
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -266,11 +266,14 @@
 
 (defvar csharp-tree-sitter--syntax-table)
 (defvar csharp-tree-sitter--mode-map)
+(defvar csharp-tree-sitter--indent-line-function)
 
 (defun csharp-tree-sitter--enable ()
   "Enable tree-sitter support for csharp."
+  ;; NOTE: Record lost data before configure to `tree-sitter' support.
   (setq csharp-tree-sitter--syntax-table csharp-mode-syntax-table
-        csharp-tree-sitter--mode-map csharp-mode-map)
+        csharp-tree-sitter--mode-map csharp-mode-map
+        csharp-tree-sitter--indent-line-function indent-line-function)
 
   (setq csharp-mode-syntax-table nil
         csharp-mode-map nil)
@@ -289,8 +292,10 @@
 
 (defun csharp-tree-sitter--disable ()
   "Disable tree-sitter support for csharp."
-  (setq csharp-mode-syntax-table csharp-tree-sitter--syntax-table)
-  (setq csharp-mode-map csharp-tree-sitter--mode-map)
+  ;; NOTE: Revert all previous configuration from `csharp-mode'.
+  (setq csharp-mode-syntax-table csharp-tree-sitter--syntax-table
+        csharp-mode-map csharp-tree-sitter--mode-map
+        indent-line-function csharp-tree-sitter--indent-line-function)
   (tree-sitter-hl-mode -1))
 
 ;;;###autoload


### PR DESCRIPTION
This patch resolved #215. And it changed from `major-mode` to `minor-mode`.

I notice `tree-sitter-mode` is a minor-mode hence I think we should stick to how `tree-sitter` supports other programming languages. See [emacs-tree-sitter languages page](https://ubolonton.github.io/emacs-tree-sitter/languages/).