### PR TITLE
Some tree-sitter fixes

### DIFF
--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -263,12 +263,12 @@
 (defgroup csharp-mode-indent nil "Indent lines using Tree-sitter as backend"
   :group 'tree-sitter)
 
-(defcustom csharp-mode-indent-offset 4
+(defcustom csharp-tree-sitter-indent-offset 4
   "Indent offset for csharp-mode"
   :type 'integer
   :group 'csharp)
 
-(defvar csharp-mode-indent-scopes
+(defvar tree-sitter-indent-csharp-tree-sitter-scopes
   '((indent-all . ;; these nodes are always indented
                 (accessor_declaration
                  break_statement
@@ -332,8 +332,6 @@ Key bindings:
   :group 'csharp
   :syntax-table csharp-tree-sitter-mode-syntax-table
 
-  (setq-local tree-sitter-indent-current-scopes csharp-mode-indent-scopes)
-  (setq-local tree-sitter-indent-offset csharp-mode-indent-offset)
   (setq-local indent-line-function #'tree-sitter-indent-line)
 
   ;; https://github.com/ubolonton/emacs-tree-sitter/issues/84

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -310,7 +310,12 @@
     (outdent . ;; these nodes always outdent (1 shift in opposite direction)
              (;; "}"
               case_switch_label
+
               ))
+
+    (align-to-node-line . ;; these nodes are aligned to the first column of the
+                          ;; line where the first node contained in the list is found.
+             ((block . (lambda_expression))))
     )
   "Scopes for indenting in C#.")
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -264,7 +264,7 @@
   :group 'tree-sitter)
 
 (defcustom csharp-tree-sitter-indent-offset 4
-  "Indent offset for csharp-mode"
+  "Indent offset for csharp-tree-sitter-mode."
   :type 'integer
   :group 'csharp)
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -276,6 +276,7 @@
                  parameter_list
                  conditional_expression
                  constructor_initializer
+                 argument_list
                  "."))
     (indent-rest . ;; if parent node is one of these and node is not first → indent
                  (

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -140,8 +140,8 @@
    ;; Parameter
    (parameter
     type: (identifier) @type
-    name: (identifier) @variable)
-   (parameter (identifier) @variable)
+    name: (identifier) @variable.parameter)
+   (parameter (identifier) @variable.parameter)
 
    ;; Array
    (array_rank_specifier (identifier) @variable)
@@ -161,7 +161,9 @@
    (type_of_expression (identifier) @variable)
 
    ;; Member access
-   (member_access_expression (identifier) @function)
+   (invocation_expression (member_access_expression (generic_name (identifier) @method.call)))
+   (invocation_expression (member_access_expression (identifier)\? @method.call .))
+   (member_access_expression (identifier) @variable)
 
    ;; Variable
    (variable_declaration (identifier) @type)
@@ -178,7 +180,7 @@
    (type_parameter
     (identifier) @type)
    (type_argument_list
-    (identifier) @type)
+    (identifier) @type.argument)
    (generic_name
     (identifier) @type)
    (implicit_type) @type
@@ -236,15 +238,15 @@
    (argument_list
     (identifier) @variable)
    (label_name) @variable
-   (qualified_name (identifier) @type)
-   (using_directive (identifier)* @type)
+   (using_directive (identifier) @type.parameter)
+   (qualified_name (identifier) @type.parameter)
+   (using_directive (name_equals (identifier) @type.parameter))
    (await_expression (identifier)* @function)
    (invocation_expression (identifier) @function)
    (element_access_expression (identifier) @variable)
    (conditional_access_expression (identifier) @variable)
    (member_binding_expression (identifier) @variable)
-   (name_colon (identifier)* @variable)
-   (name_equals (identifier) @type)
+   (name_colon (identifier)* @variable.special)
    (field_declaration)
    (argument (identifier) @variable)
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -313,9 +313,12 @@
 
               ))
 
-    (align-to-node-line . ;; these nodes are aligned to the first column of the
-                          ;; line where the first node contained in the list is found.
-             ((block . (lambda_expression))))
+    (align-to-node-line . ;; this group has lists of alist (node type . (node types... ))
+	                      ;; we move parentwise, searching for one of the node
+	                      ;; types associated with the key node type. if found,
+                          ;; align key node with line where the ancestor node
+	                      ;; was found.
+			 ((block . (lambda_expression))))
     )
   "Scopes for indenting in C#.")
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -314,11 +314,11 @@
               ))
 
     (align-to-node-line . ;; this group has lists of alist (node type . (node types... ))
-	                      ;; we move parentwise, searching for one of the node
-	                      ;; types associated with the key node type. if found,
+                          ;; we move parentwise, searching for one of the node
+                          ;; types associated with the key node type. if found,
                           ;; align key node with line where the ancestor node
-	                      ;; was found.
-			 ((block . (lambda_expression))))
+                          ;; was found.
+             ((block . (lambda_expression))))
     )
   "Scopes for indenting in C#.")
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -263,8 +263,8 @@
 (defgroup csharp-mode-indent nil "Indent lines using Tree-sitter as backend"
   :group 'tree-sitter)
 
-(defcustom csharp-indent-offset 4
-  "Indent offset for csharp-mode."
+(defcustom csharp-tree-sitter-indent-offset 4
+  "Indent offset for csharp-mode"
   :type 'integer
   :group 'csharp)
 
@@ -381,7 +381,6 @@ Key bindings:
   (setq-local comment-start "// ")
   (setq-local comment-start-skip "\\(?://+\\|/\\*+\\)\\s *")
   (setq-local comment-end "")
-  (defvaralias 'csharp-tree-sitter-indent-offset 'csharp-indent-offset)
 
   (tree-sitter-hl-mode)
   (tree-sitter-indent-mode))

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -345,7 +345,8 @@ Key bindings:
   (setq-local comment-end "")
   (defvaralias 'csharp-tree-sitter-indent-offset 'csharp-indent-offset)
 
-  (tree-sitter-hl-mode))
+  (tree-sitter-hl-mode)
+  (tree-sitter-indent-mode))
 
 (add-to-list 'tree-sitter-major-mode-language-alist '(csharp-tree-sitter-mode . c-sharp))
 

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -263,8 +263,8 @@
 (defgroup csharp-mode-indent nil "Indent lines using Tree-sitter as backend"
   :group 'tree-sitter)
 
-(defcustom csharp-tree-sitter-indent-offset 4
-  "Indent offset for csharp-mode"
+(defcustom csharp-indent-offset 4
+  "Indent offset for csharp-mode."
   :type 'integer
   :group 'csharp)
 
@@ -343,6 +343,7 @@ Key bindings:
   (setq-local comment-start "// ")
   (setq-local comment-start-skip "\\(?://+\\|/\\*+\\)\\s *")
   (setq-local comment-end "")
+  (defvaralias 'csharp-tree-sitter-indent-offset 'csharp-indent-offset)
 
   (tree-sitter-hl-mode))
 


### PR DESCRIPTION
Added a pattern for method call after method access.

Differentiate various pattern to allow customization.

Fixed tree-sitter-indent-mode initialization by renaming the `csharp-mode-indent-scopes` and `csharp-mode-indent-offset` variables.

Added `argument_list` to the always indent rule.