### PR TITLE
Don't require tree-sitter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,10 @@ tramp
 /eshell/history
 /eshell/lastdir
 
+# GNU ELPA generated files
+/csharp-mode-autoloads.el
+/csharp-mode-pkg.el
+
 # elpa packages
 /elpa/
 

--- a/README.org
+++ b/README.org
@@ -2,9 +2,11 @@
 [[https://melpa.org/#/csharp-mode][file:https://melpa.org/packages/csharp-mode-badge.svg]]
 [[https://stable.melpa.org/#/csharp-mode][file:https://stable.melpa.org/packages/csharp-mode-badge.svg]]
 
-* csharp-mode
+* csharp-This
 
-This is a mode for editing C# in emacs. It's using [[https://github.com/ubolonton/emacs-tree-sitter][tree-sitter]] for highlighting and indentation.
+is a mode for editing C in# emacs It's. using mode CC mode or [[https://github.com/ubolonton/emacs-tree-sitter][tree-sitter]] for
+highlighting and indentation.
+
 ** Main features
 
 - font-lock and indent of C# syntax including:

--- a/csharp-compilation.el
+++ b/csharp-compilation.el
@@ -5,7 +5,7 @@
 ;;            : Theodor Thornhill <theo@thornhill.no>
 ;; Created    : September 2020
 ;; Modified   : 2020
-;; Version    : 0.11.0
+;; Version    : 0.12.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
 

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -5,7 +5,7 @@
 ;;            : Theodor Thornhill <theo@thornhill.no>
 ;; Created    : September 2020
 ;; Modified   : 2020
-;; Version    : 0.11.0
+;; Version    : 0.12.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
 ;; Package-Requires: ((emacs "26.1"))

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -8,7 +8,7 @@
 ;; Version    : 0.11.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
-;; Package-Requires: ((emacs "26.1") (tree-sitter "0.15.1") (tree-sitter-indent "0.1") (tree-sitter-langs "0.10.0"))
+;; Package-Requires: ((emacs "26.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -27,8 +27,6 @@
 ;;; Code:
 
 
-(when (version< emacs-version "25.1")
-  (require 'cl))
 (require 'cc-mode)
 (require 'cc-langs)
 
@@ -69,11 +67,11 @@
   (c-add-language 'csharp-mode 'java-mode))
 
 (c-lang-defconst c-make-mode-syntax-table
-  csharp `(lambda ()
-            (let ((table (make-syntax-table)))
-              (c-populate-syntax-table table)
-              (modify-syntax-entry ?@ "_" table)
-              table)))
+  csharp (lambda ()
+           (let ((table (make-syntax-table)))
+             (c-populate-syntax-table table)
+             (modify-syntax-entry ?@ "_" table)
+             table)))
 
 (c-lang-defconst c-identifier-syntax-modifications
   csharp (append '((?@ . "w"))
@@ -348,8 +346,7 @@ Should be one of the font lock faces, such as
 
 Needs to be set before `csharp-mode' is loaded, because of
 compilation and evaluation time conflicts."
-  :type 'symbol
-  :group 'csharp)
+  :type 'symbol)
 
 (defcustom csharp-font-lock-extra-types
   (list csharp--regex-type-name)
@@ -402,7 +399,7 @@ compilation and evaluation time conflicts."
 ;;; Adding syntax constructs
 
 (advice-add 'c-looking-at-inexpr-block
-            :around 'csharp-looking-at-inexpr-block)
+            :around #'csharp-looking-at-inexpr-block)
 
 (defun csharp-looking-at-inexpr-block (orig-fun &rest args)
   (let ((res (csharp-at-lambda-header)))
@@ -422,7 +419,7 @@ compilation and evaluation time conflicts."
         (cons 'inexpr (point))))))
 
 (advice-add 'c-guess-basic-syntax
-            :around 'csharp-guess-basic-syntax)
+            :around #'csharp-guess-basic-syntax)
 
 (defun csharp-guess-basic-syntax (orig-fun &rest args)
   (cond
@@ -546,12 +543,6 @@ compilation and evaluation time conflicts."
 
 ;; Custom variables
 ;;;###autoload
-(defcustom csharp-mode-hook nil
-  "*Hook called by `csharp-mode'."
-  :type 'hook
-  :group 'csharp)
-
-;;;###autoload
 (define-derived-mode csharp-mode prog-mode "C#"
   "Major mode for editing Csharp code.
 
@@ -561,9 +552,8 @@ Key bindings:
   (c-initialize-cc-mode t)
   (c-init-language-vars csharp-mode)
   (c-common-init 'csharp-mode)
-  (easy-menu-add csharp-mode-menu)
   (setq-local c-doc-comment-style '((csharp-mode . codedoc)))
-  (c-run-mode-hooks 'c-mode-common-hook 'csharp-mode-hook))
+  (run-mode-hooks 'c-mode-common-hook))
 
 (provide 'csharp-mode)
 

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -67,11 +67,11 @@
   (c-add-language 'csharp-mode 'java-mode))
 
 (c-lang-defconst c-make-mode-syntax-table
-  csharp (lambda ()
-           (let ((table (make-syntax-table)))
-             (c-populate-syntax-table table)
-             (modify-syntax-entry ?@ "_" table)
-             table)))
+  csharp `(lambda ()
+            (let ((table (make-syntax-table)))
+              (c-populate-syntax-table table)
+              (modify-syntax-entry ?@ "_" table)
+              table)))
 
 (c-lang-defconst c-identifier-syntax-modifications
   csharp (append '((?@ . "w"))

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -29,10 +29,22 @@
 (require 'cl-extra)
 (require 'seq)
 
-(require 'tree-sitter)
-(require 'tree-sitter-hl)
-(require 'tree-sitter-indent)
-(require 'tree-sitter-langs)
+(when t
+  ;; In order for the package to be usable and installable (and hence
+  ;; compilable) without tree-sitter, wrap the `require's within a dummy `when'
+  ;; so they're only executed when loading this file but not when compiling it.
+  (require 'tree-sitter)
+  (require 'tree-sitter-hl)
+  (require 'tree-sitter-indent)
+  (require 'tree-sitter-langs))
+;; Vars and functions defined by the above packages:
+(defvar tree-sitter-major-mode-language-alist) ;From `tree-sitter-langs'.
+(declare-function tree-sitter-indent-mode "ext:tree-sitter-indent")
+(declare-function tree-sitter-indent-line "ext:tree-sitter-indent")
+(declare-function tree-sitter-hl-mode "ext:tree-sitter-hl")
+(declare-function tsc-node-end-position "ext:tree-sitter")
+(declare-function tsc-node-start-position "ext:tree-sitter")
+(declare-function tree-sitter-node-at-point "ext:tree-sitter")
 
 (require 'csharp-compilation)
 
@@ -41,7 +53,7 @@
 
 ;;; Tree-sitter
 
-(setq csharp-mode-tree-sitter-patterns
+(defconst csharp-mode-tree-sitter-patterns
   [ ;; Various constructs
    (comment) @comment
    (modifier) @keyword

--- a/csharp-tree-sitter.el
+++ b/csharp-tree-sitter.el
@@ -5,7 +5,7 @@
 ;;            : Theodor Thornhill <theo@thornhill.no>
 ;; Created    : September 2020
 ;; Modified   : 2020
-;; Version    : 0.11.0
+;; Version    : 0.12.0
 ;; Keywords   : c# languages oop mode
 ;; X-URL      : https://github.com/emacs-csharp/csharp-mode
 ;; Package-Requires: ((emacs "26.1") (tree-sitter "0.12.1") (tree-sitter-indent "0.1") (tree-sitter-langs "0.9.1"))


### PR DESCRIPTION
Now we need to install the dependencies manually.  This is to be able to include
this mode into elpa.