### PR TITLE
`files` directive is not needed so delete this

### DIFF
--- a/Cask
+++ b/Cask
@@ -2,4 +2,3 @@
 (source melpa)
 
 (package-file "csharp-mode.el")
-(files "*.el")


### PR DESCRIPTION
And because of this, useless files are recognized as package files.

Before this commit
```
    $ cask files
    csharp-compilation.el
    csharp-mode-tests.el
    csharp-mode.el
    csharp-tree-sitter.el
```

After this commit
```
    $ cask files
    csharp-compilation.el
    csharp-mode.el
    csharp-tree-sitter.el
```