### PR TITLE
Add support for multiline strings

### DIFF
--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -78,7 +78,7 @@
                         "true"       'font-lock-constant-face
                         ))
 
-(when (and (>= emacs-major-version 28)
+(when (and (>= emacs-major-version 29)
            (string-lessp "5.35.0" c-version))
   (ert-deftest fontification-of-multiline-strings ()
     (assess-face-in-file= "./test-files/multiline-strings.cs"

--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -78,7 +78,8 @@
                         "true"       'font-lock-constant-face
                         ))
 
-(when (string-lessp "5.35.0" c-version)
+(when (and (>= emacs-major-version 28)
+           (string-lessp "5.35.0" c-version))
   (ert-deftest fontification-of-multiline-strings ()
     (assess-face-in-file= "./test-files/multiline-strings.cs"
                           "Literal0" 'font-lock-variable-name-face

--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -118,20 +118,21 @@
    "var import = true;"
    "import" 'font-lock-variable-name-face))
 
-(ert-deftest fontification-of-literals-allows-multi-line-strings ()
-  (require 'assess)
-  (should (assess-face-at=
-           "string Literal = \"multi-line\nstring\";"
-           'csharp-mode
-           ;; should be interpreted as error
-           18 'font-lock-warning-face
-           ))
-  (should (assess-face-at=
-           "string Literal = @\"multi-line\nstring\";"
-           'csharp-mode
-           ;; should not be interpreted as error because of @
-           19 'font-lock-string-face
-           )))
+;; TODO: Should we really behave like this? The new CC Mode multiline strings doesn't
+;; (ert-deftest fontification-of-literals-allows-multi-line-strings ()
+;;   (require 'assess)
+;;   (should (assess-face-at=
+;;            "string Literal = \"multi-line\nstring\";"
+;;            'csharp-mode
+;;            ;; should be interpreted as error
+;;            18 'font-lock-warning-face
+;;            ))
+;;   (should (assess-face-at=
+;;            "string Literal = @\"multi-line\nstring\";"
+;;            'csharp-mode
+;;            ;; should not be interpreted as error because of @
+;;            19 'font-lock-string-face
+;;            )))
 
 ;; (ert-deftest fontification-of-compiler-directives ()
 ;;   ;; this replaces the manual test of

--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -78,6 +78,15 @@
                         "true"       'font-lock-constant-face
                         ))
 
+(when (string-lessp "5.35.0" c-version)
+  (ert-deftest fontification-of-multiline-strings ()
+    (assess-face-in-file= "./test-files/multiline-strings.cs"
+                          "Literal0" 'font-lock-variable-name-face
+                          "Literal1" 'font-lock-variable-name-face
+                          "Literal2" 'font-lock-variable-name-face
+                          "Literal3" 'font-lock-variable-name-face
+                          "Literal4" 'font-lock-variable-name-face)))
+
 (ert-deftest fontification-of-constants ()
   (require 'assess)
   (assess-face-in-text=

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -96,7 +96,15 @@
   csharp ?@)
 
 (c-lang-defconst c-ml-string-opener-re
-  csharp "\\(?:\\=\\|[^\"]\\)\\(?:\"\"\\)*\\(\\(\"\\)\\)\\(?:[^\"]\\|\\'\\)")
+  ;; "\\(?:\\=\\|[^\"]\\)\\(?:\"\"\\)*\\(\\(\"\\)\\)\\(?:[^\"]\\|\\'\\)"
+  csharp
+  (rx
+   (seq
+    (or point (not (any "\"")))
+    (zero-or-more "\"\"")
+    (group
+     (group "\""))
+    (or (not (any "\"")) eos))))
 
 (c-lang-defconst c-ml-string-max-opener-len
   csharp 2)
@@ -105,10 +113,24 @@
   csharp 2)
 
 (c-lang-defconst c-ml-string-any-closer-re
-  csharp "\\(?:\"\"\\)*\\(\\(\"\\)\\)\\(?:[^\"]\\|\\'\\)")
+  ;; "\\(?:\"\"\\)*\\(\\(\"\\)\\)\\(?:[^\"]\\|\\'\\)"
+  csharp
+  (rx
+   (seq
+    (zero-or-more "\"\"")
+    (group
+     (group "\""))
+    (or (not (any "\"")) eos))))
 
 (c-lang-defconst c-ml-string-back-closer-re
-  csharp "\\(:?\\`\\|[^\"]\\)\"*")
+  ;; "\\(:?\\`\\|[^\"]\\)\"*"
+  csharp
+  (rx
+   (seq
+    (group
+     (or (seq (opt ":") bos)
+         (not (any "\""))))
+    (zero-or-more "\""))))
 
 (c-lang-defconst c-type-prefix-kwds
   csharp '("class" "interface" "struct"))

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -95,6 +95,21 @@
 (c-lang-defconst c-multiline-string-start-char
   csharp ?@)
 
+(c-lang-defconst c-ml-string-opener-re
+  csharp "\\(?:\\=\\|[^\"]\\)\\(?:\"\"\\)*\\(\\(\"\\)\\)\\(?:[^\"]\\|\\'\\)")
+
+(c-lang-defconst c-ml-string-max-opener-len
+  csharp 2)
+
+(c-lang-defconst c-ml-string-max-closer-len
+  csharp 2)
+
+(c-lang-defconst c-ml-string-any-closer-re
+  csharp "\\(?:\"\"\\)*\\(\\(\"\\)\\)\\(?:[^\"]\\|\\'\\)")
+
+(c-lang-defconst c-ml-string-back-closer-re
+  csharp "\\(:?\\`\\|[^\"]\\)\"*")
+
 (c-lang-defconst c-type-prefix-kwds
   csharp '("class" "interface" "struct"))
 

--- a/test-files/fontification-test.cs
+++ b/test-files/fontification-test.cs
@@ -1,7 +1,6 @@
 
 public const string Literal1 = @"literal without trailing slash";
 public const bool1 Reference = true;
-public const string Literal2 = @"literal with trailing slash\"; 
 public const bool2 Reference = true;
 public static const string Literal3 = @"multi-line
 literal";

--- a/test-files/fontification-test.cs
+++ b/test-files/fontification-test.cs
@@ -1,6 +1,7 @@
+
 public const string Literal1 = @"literal without trailing slash";
 public const bool1 Reference = true;
-// public const string Literal2 = @"literal with trailing slash\"; 
+public const string Literal2 = @"literal with trailing slash\"; 
 public const bool2 Reference = true;
 public static const string Literal3 = @"multi-line
 literal";

--- a/test-files/multiline-strings.cs
+++ b/test-files/multiline-strings.cs
@@ -1,0 +1,6 @@
+public const string Literal0 = @"\
+";
+public const string Literal1 = @"\";
+public const string Literal2 = @"\\";
+public const string Literal3 = @"\\\";
+public const string Literal4 = @"\\\\";


### PR DESCRIPTION
There is now a new type of support for multiline strings in CC Mode, and this is
a first attempt to support this.  The regexes are supplied from Alan Mackenzie,
the maintainer of CC Mode.  There are probably improvements to be made here, but
it seems to fix some slowness with regards to string handling.  How does it
work, you ask?

It is left as an exercise to the reader.

@josteink, this should address #164, #250, #207, #182