### PR TITLE
Replace Cask with Eask?

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,9 +9,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  unix-build:
+  build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         emacs-version: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1, snapshot]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-latest]
-        emacs: [26.1, 26.2, 26.3, 27.1, 27.2, snapshot]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        emacs-version: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1, snapshot]
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
@@ -26,43 +26,22 @@ jobs:
           architecture: "x64"
 
       - uses: purcell/setup-emacs@master
+        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         with:
           version: ${{ matrix.emacs }}
-
-      - uses: conao3/setup-cask@master
-        with:
-          version: 0.8.4
-
-      - name: paths
-        run: |
-          echo "$HOME/.cask/bin" >> $GITHUB_PATH
-
-      - name: Run a multi-line script
-        run: |
-          emacs --version
-          make test
-
-  windows-build:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        emacs: [26.1, 26.2, 26.3, 27.1, 27.2, snapshot]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.6"
-          architecture: "x64"
 
       - uses: jcs090218/setup-emacs-windows@master
+        if: matrix.os == 'windows-latest'
         with:
           version: ${{ matrix.emacs }}
 
-      - uses: conao3/setup-cask@master
+      - uses: actions/setup-node@v2
         with:
-          version: 0.8.4
+          node-version: '14'
+
+      - uses: emacs-eask/setup-eask@master
+        with:
+          version: 'snapshot'
 
       - name: Run a multi-line script
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,4 +42,4 @@ jobs:
       - name: Run a multi-line script
         run: |
           emacs --version
-          make test
+          make ci

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
 
       - uses: emacs-eask/setup-eask@master
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,6 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-python@v2
-        with:
-          python-version: "3.6"
-          architecture: "x64"
-
       - uses: purcell/setup-emacs@master
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,12 @@ jobs:
       - uses: purcell/setup-emacs@master
         if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
         with:
-          version: ${{ matrix.emacs }}
+          version: ${{ matrix.emacs-version }}
 
       - uses: jcs090218/setup-emacs-windows@master
         if: matrix.os == 'windows-latest'
         with:
-          version: ${{ matrix.emacs }}
+          version: ${{ matrix.emacs-version }}
 
       - uses: actions/setup-node@v2
         with:

--- a/Cask
+++ b/Cask
@@ -1,4 +1,0 @@
-(source gnu)
-(source melpa)
-
-(package-file "csharp-mode.el")

--- a/Eask
+++ b/Eask
@@ -9,4 +9,7 @@
 
 (depends-on "emacs" "26.1")
 
+(development
+ (depends-on "dash"))
+
 (setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Eask
+++ b/Eask
@@ -1,0 +1,12 @@
+(package "csharp-mode"
+         "1.1.1"
+         "C# mode derived mode")
+
+(package-file "csharp-mode.el")
+
+(source "gnu")
+(source "melpa")
+
+(depends-on "emacs" "26.1")
+
+(setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/Eask
+++ b/Eask
@@ -10,6 +10,8 @@
 (depends-on "emacs" "26.1")
 
 (development
- (depends-on "dash"))
+ (depends-on "assess")
+ (depends-on "dash")
+ (depends-on "m-buffer"))
 
 (setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -23,22 +23,6 @@
 (require 'csharp-mode)
 (require 'package)
 
-;; development only packages, not declared as a package-dependency
-;; FIXME: loading a .el file from `load-path' should not change user's settings
-;; like that.  It can happen without the user explicitly requesting it!
-(package-initialize)
-(add-to-list 'package-archives '("melpa" . "https://stable.melpa.org/packages/"))
-
-;; required to resolve SEQ (or anything on elpa) on Emacs25.
-(setq package-check-signature nil)
-
-;; assess depends on dash 2.12.1, which is no longer available
-;; installing dash, resolves 2.13.0, and fixes this broken dependency.
-(dolist (p '(dash assess))
-  (when (not (package-installed-p p))
-    (package-refresh-contents)
-    (package-install p)))
-
 ;;; test-helper functions
 
 (defmacro assess-face-in-text= (testee &rest assessments)

--- a/makefile
+++ b/makefile
@@ -1,20 +1,20 @@
 EMACS ?= emacs
-CASK ?= cask
+EASK ?= eask
 
 TESTHOME=/tmp/emacs
 
 package: build
-	$(CASK) package
+	$(EASK) package
 
 build: test
-	$(CASK) build
+	$(EASK) build
 
 test:
 	@echo "Testing..."
-	@$(CASK) $(EMACS) -Q -batch -L . -l csharp-mode-tests.el -f ert-run-tests-batch-and-exit
+	$(EMACS) -Q -batch -L . -l csharp-mode-tests.el -f ert-run-tests-batch-and-exit
 
 clean:
-	$(CASK) clean-elc
+	$(EASK) clean-elc
 	rm -rf dist
 	rm -rf $(TESTHOME)
 

--- a/makefile
+++ b/makefile
@@ -3,11 +3,13 @@ EASK ?= eask
 
 TESTHOME=/tmp/emacs
 
-package: build
+ci: build test
+
+package:
 	$(EASK) package
 
-build: test
-	$(EASK) build
+build: package
+	$(EASK) install
 
 test:
 	@echo "Testing..."

--- a/makefile
+++ b/makefile
@@ -13,6 +13,7 @@ build: package
 
 test:
 	@echo "Testing..."
+	$(EASK) install --dev
 	$(EASK) ert csharp-mode-tests.el
 
 clean:

--- a/makefile
+++ b/makefile
@@ -11,7 +11,7 @@ build: test
 
 test:
 	@echo "Testing..."
-	$(EMACS) -Q -batch -L . -l csharp-mode-tests.el -f ert-run-tests-batch-and-exit
+	$(EASK) ert csharp-mode-tests.el
 
 clean:
 	$(EASK) clean-elc


### PR DESCRIPTION
Hi, I have recently created a tool named [Eask](https://github.com/emacs-eask/eask). It's similar to Cask, but it has a better cross-platform capability. 

This patch does the following:

1. Replace Cask with Eask
2. Add test for Emacs 28.1
3. `build.yml` now has only one job (merged unix + windows)
4. Clean up manual installation in the beginning of the test file `csharp-mode-tests.el`

https://github.com/emacs-csharp/csharp-mode/blob/856ecbc0a78ae3bdc2db2ae4d16be43e2d9d9c5e/csharp-mode-tests.el#L26-L40

and replace it with Eask's `depends-on` directive.

---

Let me know what you guys think? Thanks!
