### PR TITLE
Use merged setup-emacs action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,13 +21,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - uses: purcell/setup-emacs@master
-        if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
-        with:
-          version: ${{ matrix.emacs-version }}
-
-      - uses: jcs090218/setup-emacs-windows@master
-        if: matrix.os == 'windows-latest'
+      - uses: jcs090218/setup-emacs@master
         with:
           version: ${{ matrix.emacs-version }}
 


### PR DESCRIPTION
I have recently created the new action [jcs090218/setup-emacs](https://github.com/jcs090218/setup-emacs). It should 
automatically pick up the right Emacs to install for each platform.