### PR TITLE
tests(makefile): Add compile to CI test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,11 +11,23 @@ on:
 jobs:
   build:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        emacs-version: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1, snapshot]
+        emacs-version: [26.1, 26.2, 26.3, 27.1, 27.2, 28.1]
+        experimental: [false]
+        include:
+        - os: ubuntu-latest
+          emacs-version: snapshot
+          experimental: true
+        - os: macos-latest
+          emacs-version: snapshot
+          experimental: true
+        - os: windows-latest
+          emacs-version: snapshot
+          experimental: true
 
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/csharp-mode.el
+++ b/csharp-mode.el
@@ -66,15 +66,15 @@
     declaration."))
 
 (eval-and-compile
-  (c-add-language 'csharp-mode 'java-mode))
+  (c-add-language 'csharp-mode 'java-mode)
 
-(defun csharp--make-mode-syntax-table ()
-  (let ((table (make-syntax-table)))
-    (c-populate-syntax-table table)
-    (modify-syntax-entry ?@ "_" table)
-    table))
-(defvar csharp--make-mode-syntax-table #'csharp--make-mode-syntax-table
-  "Workaround for Emacs bug#57065.")
+  (defun csharp--make-mode-syntax-table ()
+    (let ((table (make-syntax-table)))
+      (c-populate-syntax-table table)
+      (modify-syntax-entry ?@ "_" table)
+      table))
+  (defvar csharp--make-mode-syntax-table #'csharp--make-mode-syntax-table
+    "Workaround for Emacs bug#57065."))
 
 (c-lang-defconst c-make-mode-syntax-table
   csharp #'csharp--make-mode-syntax-table)

--- a/makefile
+++ b/makefile
@@ -3,13 +3,16 @@ EASK ?= eask
 
 TESTHOME=/tmp/emacs
 
-ci: build test
+ci: build compile test
 
 package:
 	$(EASK) package
 
 build: package
 	$(EASK) install
+
+compile:
+	$(EASK) compile
 
 test:
 	@echo "Testing..."

--- a/makefile
+++ b/makefile
@@ -10,8 +10,6 @@ package:
 
 build: package
 	$(EASK) install
-
-compile:
 	$(EASK) compile
 
 test:

--- a/makefile
+++ b/makefile
@@ -3,7 +3,7 @@ EASK ?= eask
 
 TESTHOME=/tmp/emacs
 
-ci: build compile test
+ci: build test
 
 package:
 	$(EASK) package


### PR DESCRIPTION
There is currently an compile error while installing, make CI aware of it.

```
csharp-mode.el:399:1:Error: Symbol’s function definition is void: csharp--make-mode-syntax-table
```