### PR TITLE
Remove dependency on dash

### DIFF
--- a/Eask
+++ b/Eask
@@ -11,7 +11,6 @@
 
 (development
  (depends-on "assess")
- (depends-on "dash")
  (depends-on "m-buffer"))
 
 (setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432

--- a/csharp-mode-tests.el
+++ b/csharp-mode-tests.el
@@ -34,9 +34,7 @@
   (setq package-check-signature nil)
   (setq network-security-level 'low)  ; see https://github.com/jcs090218/setup-emacs-windows/issues/156#issuecomment-932956432
 
-  ;; assess depends on dash 2.12.1, which is no longer available
-  ;; installing dash, resolves 2.13.0, and fixes this broken dependency.
-  (dolist (p '(dash assess))
+  (dolist (p '(assess))
     (when (not (package-installed-p p))
       (package-refresh-contents)
       (package-install p))))


### PR DESCRIPTION
As of assess v0.4, it's using seq rather than dash: https://github.com/phillord/assess/commit/deb6e4cb236dcda804daaf28e7809488e4b8ee76