### PR TITLE
tests: Setup node is no longer required

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,10 +37,6 @@ jobs:
         with:
           version: ${{ matrix.emacs-version }}
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-
       - uses: emacs-eask/setup-eask@master
         with:
           version: 'snapshot'

--- a/Eask
+++ b/Eask
@@ -2,6 +2,9 @@
          "1.1.1"
          "C# mode derived mode")
 
+(website-url "https://github.com/emacs-csharp/csharp-mode")
+(keywords "c#" "languages" "oop" "mode")
+
 (package-file "csharp-mode.el")
 
 (source "gnu")


### PR DESCRIPTION
This is no longer needed for [setup-eask](https://github.com/emacs-eask/setup-eask).